### PR TITLE
Make the arguments pass as real arguments

### DIFF
--- a/mcl
+++ b/mcl
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 export JAVA_BINARY=java
-$JAVA_BINARY -jar mcl.jar "$*"
+$JAVA_BINARY -jar mcl.jar $*


### PR DESCRIPTION
The quotes between `$*` would make it a single argument. This would prevent the parser from parsing these arguments correctly, hence the issue #4.