### PR TITLE
Add version forcing feature

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,7 @@ usage: mcl
  -u,--disable-update                 Disable auto update
  -v,--set-maven-repo <Address>       Set Maven Repo address
  -w,--version <Version>              Set version of package
+ -x,--force-version                  Force downloading specified version
  -z,--dry-run                        Only download libraries without
                                      running them
 ```

--- a/scripts/updater.js
+++ b/scripts/updater.js
@@ -59,7 +59,7 @@ function check(pack) {
     } else {
         let target = info.channels[pack.channel];
         let ver = target[target.size() - 1];
-        if ((!update && !pack.version.equals(ver)) || (update && !target.contains(ver) && !force)) {
+        if ((!update && !pack.version.equals(ver)) || (update && !target.contains(pack.version) && !force)) {
             pack.version = ver;
             down = true;
         }

--- a/scripts/updater.js
+++ b/scripts/updater.js
@@ -29,6 +29,7 @@ importPackage(java.lang);
 importPackage(java.math);
 
 loader.options.addOption(Option.builder("u").desc("Disable auto update").longOpt("disable-update").build());
+loader.options.addOption(Option.builder("x").desc("Force downloading specified version").longOpt("force-version").build());
 
 phase.load = () => {
     let packages = loader.config.packages;
@@ -46,9 +47,10 @@ function checkLocalFile(pack) {
 function check(pack) {
     logger.info("Verifying \"" + pack.id + "\" version " + pack.version);
     let update = loader.cli.hasOption("u");
+    let force = loader.cli.hasOption("x");
     let down = false;
     if (!checkLocalFile(pack)) {
-        logger.info("\"" + pack.id + "\" is corrupted. Start downloading...");
+        logger.info("\"" + pack.id + ":" + pack.version + "\" is corrupted. Start downloading...");
         down = true;
     }
     let info = loader.repo.fetchPackage(pack.id);
@@ -57,7 +59,7 @@ function check(pack) {
     } else {
         let target = info.channels[pack.channel];
         let ver = target[target.size() - 1];
-        if ((!update && !pack.version.equals(ver)) || (update && !target.contains(pack.version))) {
+        if ((!update && !pack.version.equals(ver)) || (update && !target.contains(ver) && !force)) {
             pack.version = ver;
             down = true;
         }
@@ -121,3 +123,4 @@ function down(url, file) {
     System.out.print(emptyString.substr(0, size) + '\r');
     System.out.println(" Downloading " + name + " " + buildDownloadBar(1, 1) + " " + ttl);
 }
+

--- a/src/main/java/org/itxtech/mcl/Utility.java
+++ b/src/main/java/org/itxtech/mcl/Utility.java
@@ -50,7 +50,9 @@ public class Utility {
         } while (numRead != -1);
 
         fis.close();
-        return new BigInteger(1, digest.digest()).toString(16);
+        byte[] bytes = digest.digest();
+        BigInteger b = new BigInteger(1, bytes);
+        return String.format("%0" + (bytes.length << 1) + "x", b);
     }
 
     public static String readSmallFile(File file) throws Exception {


### PR DESCRIPTION
It might be possible that remote has published a version that is not present in the official Mirai package repository. 
Adding the `-x, --force-version` switch allows user to forcing a version even if it was not presented in the repository, which is useful for testing experimental builds, private builds and/or latest builds that haven't been rolled out yet.

When implementing this feature, I also found that the digest is not handled properly. Namely the leading `0` is omitted 
from digest output, which happened for `mirai-console:1.0-RC-1` (digest value is `0a413b8...`). I thought it should be 
addressed.

Should we also introduce `-X, --ignore-checksum` in future versions? As private builds might not provide checksums or 
provide other digests instead of SHA1.