### PR TITLE
Use error messages instead of NPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build
 out
 
 /testing
+
+
+/gradle
+gradlew
+gradlew.bat

--- a/src/main/java/org/itxtech/mcl/module/builtin/Repo.java
+++ b/src/main/java/org/itxtech/mcl/module/builtin/Repo.java
@@ -3,6 +3,7 @@ package org.itxtech.mcl.module.builtin;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.itxtech.mcl.Utility;
+import org.itxtech.mcl.component.Repository;
 import org.itxtech.mcl.module.MclModule;
 
 import java.sql.Timestamp;
@@ -77,8 +78,16 @@ public class Repo extends MclModule {
 
             if (loader.cli.hasOption("i")) {
                 var pkg = loader.cli.getOptionValue("i");
+
                 loader.logger.info("Fetching channel info for package \"" + pkg + "\"");
-                for (var chan : loader.repo.fetchPackage(pkg).channels.entrySet()) {
+                Repository.PackageInfo fetchedPackageInfo = loader.repo.fetchPackage(pkg);
+                if (null == fetchedPackageInfo) {
+                    loader.logger.error("Package \"" + pkg + "\" is not found in MiraiRepo");
+                    loader.exit(1);
+                    return;
+                }
+
+                for (var chan : fetchedPackageInfo.channels.entrySet()) {
                     loader.logger.info("---------- Channel: " + chan.getKey() + " ----------");
                     loader.logger.info("Version: " + Utility.join(", ", chan.getValue()));
                     loader.logger.info("");

--- a/src/main/java/org/itxtech/mcl/module/builtin/Repo.java
+++ b/src/main/java/org/itxtech/mcl/module/builtin/Repo.java
@@ -3,7 +3,6 @@ package org.itxtech.mcl.module.builtin;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.itxtech.mcl.Utility;
-import org.itxtech.mcl.component.Repository;
 import org.itxtech.mcl.module.MclModule;
 
 import java.sql.Timestamp;
@@ -80,7 +79,7 @@ public class Repo extends MclModule {
                 var pkg = loader.cli.getOptionValue("i");
 
                 loader.logger.info("Fetching channel info for package \"" + pkg + "\"");
-                Repository.PackageInfo fetchedPackageInfo = loader.repo.fetchPackage(pkg);
+                var fetchedPackageInfo = loader.repo.fetchPackage(pkg);
                 if (null == fetchedPackageInfo) {
                     loader.logger.error("Package \"" + pkg + "\" is not found in MiraiRepo");
                     loader.exit(1);


### PR DESCRIPTION
当使用 -i 参数无法从 MiraiRepo 获取到 package 信息时应该打印错误信息，并终止 mcl 的启动