### PR TITLE
fix: transform id to url

### DIFF
--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -70,7 +70,10 @@ public class Repository {
     }
 
     private static String transformId(String id) {
-        return id.replace(".", "/").replace(":", "/");
+        var arr =  id.split(":", 2);
+        var group = arr[0];
+        var name = arr[1];
+        return group.replace(".", "/") + "/" + name;
     }
 
     private static String getPackageFromId(String id) {


### PR DESCRIPTION
使用 maven 通道安装 libs 时， 如果 包的名字中带有 `.`, 构造的 url  会有错

例如 
`javax.annotation:javax.annotation-api`