### PR TITLE
fix: remove last `/` in mavenRepo [untested]

### DIFF
--- a/src/main/java/org/itxtech/mcl/Loader.java
+++ b/src/main/java/org/itxtech/mcl/Loader.java
@@ -115,6 +115,11 @@ public class Loader {
 
     public void loadConfig() {
         config = Config.load(configFile);
+        for (int i = 0; i < loader.config.mavenRepo.length; i ++) {
+            if(loader.config.mavenRepo[i].endsWith("/")){
+                loader.config.mavenRepo[i] = loader.config.mavenRepo[i].substring(0,loader.config.mavenRepo[i].length - 1);
+            }
+        }
         logger.setLogLevel(config.logLevel);
     }
 


### PR DESCRIPTION
If the maven repo url ends with `/`, the httpGet cannot handle it correctly.

logs:
```
"maven_repo": [
    "https://repo1.maven.org/maven2/"
  ],
```
```
F:\mirai\mcl-for-miraicp>mcl
  12:50:19 [INFO] iTXTech Mirai Console Loader version 2.1.0-71ec418
  12:50:19 [INFO] https://github.com/iTXTech/mirai-console-loader
  12:50:19 [INFO] This program is licensed under GNU AGPL v3
  12:50:20 [INFO] Mirai Console Loader Announcement:
Mirai Console Loader 公告栏

如果在图片上传的时候遇到问题请与我们联系 (需要提供图片文件源本)
`- 如 Unsupported image type for ExternalResource *
`  considering use gif/png/bmp/jpg format.
`- Tracker: https://github.com/mamoe/mirai/issues/new/choose

常用资源整合
`- https://mirai.mamoe.net/topic/653

MCL 已推出 2.1.0，更好的支持 Mirai 2.11 的插件系统，建议更新。

  12:50:20 [INFO] Verifying "net.mamoe:mirai-console" v2.12.1
  12:50:20 [ERROR] "net.mamoe:mirai-console" is corrupted.
  12:50:20 [INFO] Updating "net.mamoe:mirai-console" to v2.12.1
  12:50:20 [ERROR] Cannot download package "net.mamoe:mirai-console"
  12:50:20 [ERROR] The local file "net.mamoe:mirai-console" is still corrupted, please check the network.
  12:50:20 [INFO] Verifying "net.mamoe:mirai-console-terminal" v2.12.1
  12:50:20 [ERROR] "net.mamoe:mirai-console-terminal" is corrupted.
  12:50:20 [INFO] Updating "net.mamoe:mirai-console-terminal" to v2.12.1
  12:50:20 [ERROR] Cannot download package "net.mamoe:mirai-console-terminal"
  12:50:20 [ERROR] The local file "net.mamoe:mirai-console-terminal" is still corrupted, please check the network.
  12:50:20 [INFO] Verifying "net.mamoe:mirai-core-all" v2.12.1
  12:50:20 [ERROR] "net.mamoe:mirai-core-all" is corrupted.
  12:50:20 [INFO] Updating "net.mamoe:mirai-core-all" to v2.12.1
  12:50:20 [ERROR] Cannot download package "net.mamoe:mirai-core-all"
  12:50:20 [ERROR] The local file "net.mamoe:mirai-core-all" is still corrupted, please check the network.
  12:50:20 [INFO] Verifying "org.itxtech:mcl-addon" v2.0.2
  12:50:20 [ERROR] "org.itxtech:mcl-addon" is corrupted.
  12:50:20 [INFO] Updating "org.itxtech:mcl-addon" to v2.0.2
  12:50:20 [ERROR] Cannot download package "org.itxtech:mcl-addon"
  12:50:20 [ERROR] The local file "org.itxtech:mcl-addon" is still corrupted, please check the network.
  12:50:20 [INFO] Verifying "org.bouncycastle:bcprov-jdk15on" v1.64
  12:50:20 [ERROR] "org.bouncycastle:bcprov-jdk15on" is corrupted.
  12:50:20 [INFO] Updating "org.bouncycastle:bcprov-jdk15on" to v1.64
  12:50:20 [ERROR] Cannot download package "org.bouncycastle:bcprov-jdk15on"
  12:50:20 [ERROR] The local file "org.bouncycastle:bcprov-jdk15on" is still corrupted, please check the network.
  12:50:20 [ERROR] java.nio.file.NoSuchFileException: libs\mirai-console-2.12.1.jar
        at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
        at java.base/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:53)
        at java.base/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:38)
        at java.base/sun.nio.fs.WindowsFileSystemProvider.readAttributes(WindowsFileSystemProvider.java:198)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1843)
        at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1198)
        at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:701)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:240)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:171)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:347)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:318)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:284)
        at org.itxtech.mcl.Utility.bootJars(Utility.java:86)
        at org.itxtech.mcl.Utility.bootJars(Utility.java:79)
        at org.itxtech.mcl.Utility.bootMirai(Utility.java:101)
        at org.itxtech.mcl.module.builtin.Boot.boot(Boot.java:109)
        at org.itxtech.mcl.module.ModuleManager.phaseBoot(ModuleManager.java:148)
        at org.itxtech.mcl.Loader.lambda$start$4(Loader.java:189)
        at org.itxtech.mcl.Loader.tryCatching(Loader.java:146)
        at org.itxtech.mcl.Loader.start(Loader.java:189)
        at org.itxtech.mcl.Loader.main(Loader.java:79)
```
log2:
```
"maven_repo": [
    "https://repo1.maven.org/maven2"
  ],
```
```
F:\mirai\mcl-for-miraicp>mcl
  12:51:40 [INFO] iTXTech Mirai Console Loader version 2.1.0-71ec418
  12:51:40 [INFO] https://github.com/iTXTech/mirai-console-loader
  12:51:40 [INFO] This program is licensed under GNU AGPL v3
  12:51:40 [INFO] Mirai Console Loader Announcement:
Mirai Console Loader 公告栏

如果在图片上传的时候遇到问题请与我们联系 (需要提供图片文件源本)
`- 如 Unsupported image type for ExternalResource *
`  considering use gif/png/bmp/jpg format.
`- Tracker: https://github.com/mamoe/mirai/issues/new/choose

常用资源整合
`- https://mirai.mamoe.net/topic/653

MCL 已推出 2.1.0，更好的支持 Mirai 2.11 的插件系统，建议更新。

  12:51:40 [INFO] Verifying "net.mamoe:mirai-console" v2.12.1
  12:51:40 [ERROR] "net.mamoe:mirai-console" is corrupted.
  12:51:40 [INFO] Updating "net.mamoe:mirai-console" to v2.12.1
 Downloading mirai-console-2.12.1.jar [==============================] 7.32 MB
 Downloading mirai-console-2.12.1.sha1 [==============================] 40 B
  12:51:41 [INFO] Verifying "net.mamoe:mirai-console-terminal" v2.12.1
  12:51:41 [ERROR] "net.mamoe:mirai-console-terminal" is corrupted.
  12:51:41 [INFO] Updating "net.mamoe:mirai-console-terminal" to v2.12.1
 Downloading mirai-console-terminal-2.12.1.jar [==============================] 1.26 MB
 Downloading mirai-console-terminal-2.12.1.sha1 [==============================] 40 B
  12:51:41 [INFO] Verifying "net.mamoe:mirai-core-all" v2.12.1
  12:51:41 [ERROR] "net.mamoe:mirai-core-all" is corrupted.
  12:51:41 [INFO] Updating "net.mamoe:mirai-core-all" to v2.12.1
 Downloading mirai-core-all-2.12.1.jar [==============================] 35.77 MB
 Downloading mirai-core-all-2.12.1.sha1 [==============================] 40 B
  12:51:43 [INFO] Verifying "org.itxtech:mcl-addon" v2.0.2
  12:51:43 [ERROR] "org.itxtech:mcl-addon" is corrupted.
  12:51:43 [INFO] Updating "org.itxtech:mcl-addon" to v2.0.2
 Downloading mcl-addon-2.0.2.jar [==============================] 51.64 KB
 Downloading mcl-addon-2.0.2.sha1 [==============================] 40 B
  12:51:43 [INFO] Verifying "org.bouncycastle:bcprov-jdk15on" v1.64
  12:51:43 [ERROR] "org.bouncycastle:bcprov-jdk15on" is corrupted.
  12:51:43 [INFO] Updating "org.bouncycastle:bcprov-jdk15on" to v1.64
 Downloading bcprov-jdk15on-1.64.jar [==============================] 4.55 MB
 Downloading bcprov-jdk15on-1.64.sha1 [==============================] 40 B
2022-09-13 12:51:45 I/main: Starting mirai-console...
```