### PR TITLE
支持下载 SNAPSHOT 版本

### DIFF
--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -180,7 +180,7 @@ public class Repository {
 
     private String getSnapshotJarUrl(String baseFolder) throws Exception {
         if (httpHead(baseFolder + "maven-metadata.xml").statusCode() != 200) return "";
-        var content = httpGet(baseFolder + "maven-metadata.xml");
+        var content = httpGet(baseFolder + "maven-metadata.xml", "");
         var factory = DocumentBuilderFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         var document = factory.newDocumentBuilder().parse(new InputSource(new StringReader(content)));

--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -88,6 +88,7 @@ public class Repository {
     public Document fetchMavenMetadata(String id) throws Exception {
         for (var repo : loader.config.mavenRepo) {
             try {
+                if (httpHead(repo + "/" + transformId(id)+ "/maven-metadata.xml").statusCode() != 200) continue;
                 var content = httpGet("/" + transformId(id) + "/maven-metadata.xml", repo);
                 var factory = DocumentBuilderFactory.newInstance();
                 factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -157,7 +157,7 @@ public class Repository {
             var base = baseFolder + getPackageFromId(pkg.id) + "-" + pkg.version;
             if (pkg.version.endsWith("-SNAPSHOT")) {
                 try {
-                    var real = getSnapshotJarUrl(baseFolder);
+                    var real = getSnapshotJarUrl(baseFolder, getPackageFromId(pkg.id), pkg.version);
                     if (!real.isEmpty()) return real;
                 } catch (Exception e) {
                     loader.logger.logException(e);
@@ -209,7 +209,7 @@ public class Repository {
         for (int i = 0; i < nodes.getLength(); i++) {
             var node = nodes.item(i);
             if (node.getNodeName().equals(name)) {
-                return node.getNodeValue();
+                return node.getTextContent().trim();
             }
         }
         return defValue;

--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -125,6 +125,7 @@ public class Repository {
                     return map.lastEntry().getValue();
                 }
             }
+            else return data.getElementsByTagName("latest").item(0).getTextContent();
         }
         return data.getElementsByTagName("release").item(0).getTextContent();
     }

--- a/src/main/java/org/itxtech/mcl/component/Repository.java
+++ b/src/main/java/org/itxtech/mcl/component/Repository.java
@@ -119,7 +119,7 @@ public class Repository {
                     }
                 }
                 if (map.size() == 0) {
-                    loader.logger.error("Cannot find any version matches channel \"" + channel + "`\" for \"" + id + "\", using default version.");
+                    loader.logger.error("Cannot find any version matches channel \"" + channel + "\" for \"" + id + "\", using default version.");
                 } else {
                     return map.lastEntry().getValue();
                 }

--- a/src/main/java/org/itxtech/mcl/module/builtin/Updater.java
+++ b/src/main/java/org/itxtech/mcl/module/builtin/Updater.java
@@ -181,9 +181,15 @@ public class Updater extends MclModule {
             );
             return;
         }
-        var index = jarUrl.lastIndexOf(name);
-        if (index != -1) {
-            jar = jarUrl.substring(index);
+        if (jarUrl.contains("|")) {
+            var split = jarUrl.split("\\|");
+            jar = split[0];
+            jarUrl = split[1];
+        } else {
+            var index = jarUrl.lastIndexOf(name);
+            if (index != -1) {
+                jar = jarUrl.substring(index);
+            }
         }
         down(jarUrl, new File(dir, jar));
 


### PR DESCRIPTION
参考仓库：https://s01.oss.sonatype.org/content/repositories/snapshots/

SNAPSHOT 版本在仓库中的链接格式不再是 `$repo/$group/$artifact/$version/$artifact-$version(-$classifier).$extension`，文件名版本号中的 `SNAPSHOT` 将会被替换为 `年月日.时分秒-编号` 格式，这使得 MCL 无法下载。

为了方便，在下载后文件名将会设为方便识别的格式，而不是下载时的文件名。

本 PR 顺便修复了
* 拼写错误 (引号里多了个<code>`</code>)
* 获取最新版本时从某一个仓库获取不到该包的 maven-metadata 时报错